### PR TITLE
Make logback editor optional

### DIFF
--- a/.atomist/editors/NewSpringBootRestMicroserviceProject.rug
+++ b/.atomist/editors/NewSpringBootRestMicroserviceProject.rug
@@ -90,7 +90,6 @@ PomParameterizer name = project_name
 PackageMove new_package = root_package
 ClassRenamer new_class = service_class_name
 AddCreationDateToReadme
-AddLogback
 DeleteLicense
 
 

--- a/.atomist/tests/NewSpringBootRestMicroserviceProject.rt
+++ b/.atomist/tests/NewSpringBootRestMicroserviceProject.rt
@@ -26,7 +26,6 @@ let group_id = "somegroup"
 let pom_path = "pom.xml"
 let readme_path = "README.md"
 let description = "And now for something completely different"
-let logback_file = "src/main/resources/logback.xml"
 
 given
   ArchiveRoot
@@ -43,8 +42,6 @@ then
   and fileContains readme_path description
   and fileExists props_file
   and fileContains props_file "server.port=8080"
-  and fileExists logback_file
-  and fileContains logback_file root_package
   and fileContains readme_path "Created by Atomist. Need Help?"
   and { !result.fileExists("LICENSE") }
 
@@ -60,7 +57,6 @@ scenario New project without description should pass smoke test
 
   let pom_path = "pom.xml"
   let readme_path = "README.md"
-  let logback_file = "src/main/resources/logback.xml"
 
   given
     ArchiveRoot
@@ -76,4 +72,4 @@ scenario New project without description should pass smoke test
     and fileContains readme_path project_name
     and fileExists props_file
     and fileContains props_file "server.port=8080"
-    and fileExists logback_file
+  


### PR DESCRIPTION
The `AddLogback` editor ended up as running for each new generation instead of just being an optional showcase for how to create an editor.